### PR TITLE
Changes name of flags key

### DIFF
--- a/Scripts/Hooks.lua
+++ b/Scripts/Hooks.lua
@@ -266,7 +266,7 @@ function Register_SaveData()
                 operation = "update",
                 value = Storage.flags
             }
-            AP_REF.APClient:Set("flags", Storage.flags, false, {operation})
+            AP_REF.APClient:Set(AP_REF.APClient:get_player_number().."-coe33-flags", Storage.flags, false, {operation})
         end
     end)
 


### PR DESCRIPTION
Changes the name of the flags key to [playerNumber]-coe33-flags. since the datastore does not use any slot specific data, keys have to be identifiable by the slot.